### PR TITLE
'admin_static' deprecated in Django 2.1 and removed since 3.0

### DIFF
--- a/djangocms_forms/templates/admin/djangocms_forms/formsubmission/export_form.html
+++ b/djangocms_forms/templates/admin/djangocms_forms/formsubmission/export_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_urls admin_static admin_modify %}
+{% load i18n admin_urls static admin_modify %}
 
 {% block bodyclass %}{{ block.super }} export-form{% endblock %}
 


### PR DESCRIPTION
With `admin_static` in template, trying to export form submissions will end with failure when running on Django>=3.0. Using `static` instead is a valid case, since `djangocms-forms` depend on django-cms>=3.0 which in turn depends on Django>=2.2 which already supports `admin_static` replacement to `static`.