### PR TITLE
remove redundant load of google.com/recaptcha/api.js

### DIFF
--- a/djangocms_forms/templates/djangocms_forms/form_template/default.html
+++ b/djangocms_forms/templates/djangocms_forms/form_template/default.html
@@ -57,9 +57,6 @@
     {% endif %}
 {% endaddtoblock %}
 {% addtoblock "js" %}
-    {% if instance.use_recaptcha %}
-        <script src="https://www.google.com/recaptcha/api.js?onload=reCapctchaOnloadCallback&render=explicit" async defer></script>
-    {% endif %}
 	<script src="{% static 'js/djangocms_forms/libs/jquery.form.min.js' %}"></script>
 	<script src="{% static 'js/djangocms_forms/jquery.djangocms-forms.js' %}"></script>
 


### PR DESCRIPTION
## Overview

Remove seemingly redundant call to `google.com/recaptcha/api.js`.

## Testing

1. Install form plugin via **base** branch on a CMS.
2. Enable captcha.
3. ⓧ Verify console error originating from the script I propose to remove.
4. Install form plugin via **this** branch on a CMS.
5. ✓ Verify console error of relevant previous step does **not** appear.

_A form using this change by me is (as of this PR) currently only available on one public webpage:
https://frontera-portal.tacc.utexas.edu/user-meeting/2022/_

⚠️ Although my rough testing proved this unnecessary, someone more familiar with the code should evaluate.

## Notes

While testing this plugin in TACC/Core-CMS, I found this call to be redundant.

Removing this block from my apps template also fixed a benign console error.

The 'django-recaptcha' app already loads this with dynamic parameters:
https://github.com/torchbox/django-recaptcha/blob/4921a6c/captcha/templates/captcha/includes/js_v2_checkbox.html#L2

Source: https://github.com/TACC/Core-CMS/pull/500/files#r898443017